### PR TITLE
Fixed the filter_terms dict in dotplot_v2.py

### DIFF
--- a/dot_plot/dot_plot_v2.py
+++ b/dot_plot/dot_plot_v2.py
@@ -614,7 +614,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
     if plot_Clinvar:
         # Define a mapping of user-input to categories
         filter_terms = {
-            'benign': ['benign'],
+            'benign': ['benign', 'benign/likely benign'],
             'likely_benign' : ['likely benign'],
             'pathogenic': ['pathogenic'],
             'likely_pathogenic': ['likely pathogenic'],
@@ -624,8 +624,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
             'likely_oncogenic': ['likely oncogenic'],
             'strong': ['strong'],
             'potential': ['potential'],
-            'unknown': ['unknown'],
-            'benign': ['benign/likely benign']}
+            'unknown': ['unknown']}
 
         # Filter dataframe according to flag option
         if 'all' in plot_Clinvar:

--- a/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_cbioportal_v2/dot_plot_v2.py
+++ b/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_cbioportal_v2/dot_plot_v2.py
@@ -614,7 +614,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
     if plot_Clinvar:
         # Define a mapping of user-input to categories
         filter_terms = {
-            'benign': ['benign'],
+            'benign': ['benign', 'benign/likely benign'],
             'likely_benign' : ['likely benign'],
             'pathogenic': ['pathogenic'],
             'likely_pathogenic': ['likely pathogenic'],
@@ -624,8 +624,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
             'likely_oncogenic': ['likely oncogenic'],
             'strong': ['strong'],
             'potential': ['potential'],
-            'unknown': ['unknown'],
-            'benign': ['benign/likely benign']}
+            'unknown': ['unknown']}
 
         # Filter dataframe according to flag option
         if 'all' in plot_Clinvar:

--- a/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_clinvar_v2/dot_plot_v2.py
+++ b/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_clinvar_v2/dot_plot_v2.py
@@ -614,7 +614,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
     if plot_Clinvar:
         # Define a mapping of user-input to categories
         filter_terms = {
-            'benign': ['benign'],
+            'benign': ['benign', 'benign/likely benign'],
             'likely_benign' : ['likely benign'],
             'pathogenic': ['pathogenic'],
             'likely_pathogenic': ['likely pathogenic'],
@@ -624,8 +624,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
             'likely_oncogenic': ['likely oncogenic'],
             'strong': ['strong'],
             'potential': ['potential'],
-            'unknown': ['unknown'],
-            'benign': ['benign/likely benign']}
+            'unknown': ['unknown']}
 
         # Filter dataframe according to flag option
         if 'all' in plot_Clinvar:

--- a/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_cosmic_v2/dot_plot_v2.py
+++ b/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_cosmic_v2/dot_plot_v2.py
@@ -614,7 +614,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
     if plot_Clinvar:
         # Define a mapping of user-input to categories
         filter_terms = {
-            'benign': ['benign'],
+            'benign': ['benign', 'benign/likely benign'],
             'likely_benign' : ['likely benign'],
             'pathogenic': ['pathogenic'],
             'likely_pathogenic': ['likely pathogenic'],
@@ -624,8 +624,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
             'likely_oncogenic': ['likely oncogenic'],
             'strong': ['strong'],
             'potential': ['potential'],
-            'unknown': ['unknown'],
-            'benign': ['benign/likely benign']}
+            'unknown': ['unknown']}
 
         # Filter dataframe according to flag option
         if 'all' in plot_Clinvar:

--- a/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_v2/dot_plot_v2.py
+++ b/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_v2/dot_plot_v2.py
@@ -614,7 +614,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
     if plot_Clinvar:
         # Define a mapping of user-input to categories
         filter_terms = {
-            'benign': ['benign'],
+            'benign': ['benign', 'benign/likely benign'],
             'likely_benign' : ['likely benign'],
             'pathogenic': ['pathogenic'],
             'likely_pathogenic': ['likely pathogenic'],
@@ -624,8 +624,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
             'likely_oncogenic': ['likely oncogenic'],
             'strong': ['strong'],
             'potential': ['potential'],
-            'unknown': ['unknown'],
-            'benign': ['benign/likely benign']}
+            'unknown': ['unknown']}
 
         # Filter dataframe according to flag option
         if 'all' in plot_Clinvar:

--- a/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_vus_v2/dot_plot_v2.py
+++ b/downstream_analysis_mavisp_templates/new_entry_templates/dotplot_vus_v2/dot_plot_v2.py
@@ -614,7 +614,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
     if plot_Clinvar:
         # Define a mapping of user-input to categories
         filter_terms = {
-            'benign': ['benign'],
+            'benign': ['benign', 'benign/likely benign'],
             'likely_benign' : ['likely benign'],
             'pathogenic': ['pathogenic'],
             'likely_pathogenic': ['likely pathogenic'],
@@ -624,8 +624,7 @@ def process_input(full_df, r_cutoff, d_cutoff, g_cutoff, residues, mutations,
             'likely_oncogenic': ['likely oncogenic'],
             'strong': ['strong'],
             'potential': ['potential'],
-            'unknown': ['unknown'],
-            'benign': ['benign/likely benign']}
+            'unknown': ['unknown']}
 
         # Filter dataframe according to flag option
         if 'all' in plot_Clinvar:


### PR DESCRIPTION
Addresses issue #36 
This PR fixes the ClinVar filtering logic in `dot_plot_v2.py` by removing a duplicated `benign` key in the `filter_terms` dictionary.