### PR TITLE
Handle empty ClinVar interpretation columns in piechart_v2

### DIFF
--- a/downstream_analysis_mavisp_templates/new_entry_templates/piechart_v2/piechart_v2.py
+++ b/downstream_analysis_mavisp_templates/new_entry_templates/piechart_v2/piechart_v2.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     except ValueError as e:
         print(f"ERROR: {e}")
         exit(1)
-    df[clinvar_cols[0]] = df[clinvar_cols[0]].str.replace(r",\s+", ",", regex=True)
+    df[clinvar_cols[0]] = df[clinvar_cols[0]].astype("string").replace(r",\s+", ",", regex=True)
    
     # Check if correct dict was provided:
     first_cell = pd.read_csv(args.dictionary, sep="\t", header=None).iat[0, 0]


### PR DESCRIPTION
Addresses issue #40 
This PR prevents `piechart_v2.py` from crashing when the selected ClinVar interpretation column exists but contains no string values, for example when it is entirely empty/NaN.

Previously, the script could fail with:

```text
AttributeError: Can only use .str accessor with string values!